### PR TITLE
Fix API Request with API KEY

### DIFF
--- a/src/Controller/Component/GeocoderComponent.php
+++ b/src/Controller/Component/GeocoderComponent.php
@@ -21,7 +21,7 @@ class GeocoderComponent extends Component
         $parameters['address'] = $address;
         $parameters['sensor'] = 'false';
 
-        $url = 'http://maps.googleapis.com/maps/api/geocode/json';
+        $url = 'https://maps.googleapis.com/maps/api/geocode/json';
 
         $http = new Client();
 


### PR DESCRIPTION
If u pass the api key in $parameters["key"], google requires the https url

See Response:
/vendor/chris48s/cakephp-geocoder/src/Controller/Component/GeocoderComponent.php (line 34)
########## DEBUG ##########
object(stdClass) {
        error_message => 'Requests to this API must be over SSL. Load the API with "https://" instead of "http://".'
        results => []
        status => 'REQUEST_DENIED'
}
###########################